### PR TITLE
change node image to slim version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts as builder
 
 WORKDIR /app
 
@@ -7,6 +7,12 @@ COPY . .
 
 RUN npm install
 RUN npm run build
+
+FROM node:lts-slim
+WORKDIR /app
+COPY --from=builder /app/build ./build
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/.env ./
 
 CMD ["node", "--env-file=.env", "build/index.js"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: node:lts-alpine
     container_name: webponpes
     ports:
       - '3000:3000'


### PR DESCRIPTION
as a reference
https://dev.to/kakisoft/dockeralpine-why-you-should-avoid-alpine-linux-44he
https://dev.to/ptuladhar3/avoid-using-bloated-nodejs-docker-image-in-production-3doc